### PR TITLE
Fix build script issues

### DIFF
--- a/webext/build.js
+++ b/webext/build.js
@@ -101,6 +101,20 @@ async function main() {
     }
   }
 
+  // Fix config paths to work in windows
+  if (path.sep != "/") {
+    for (let category of ["copy", "scss", "manifest"]) {
+      let catObj = config[category];
+      let newObj = {};
+      for (let key of Object.keys(catObj)) {
+        let keyFixed = key.replaceAll("/", path.sep);
+        let valFixed = catObj[key].replaceAll("/", path.sep);
+        newObj[keyFixed] = valFixed;
+      }
+      config[category] = newObj;
+    }
+  }
+
   let tsEntryPoints = Object.entries(config.typescript).map(([src, dst]) => ({
     in: src,
     out: dst,

--- a/webext/build.js
+++ b/webext/build.js
@@ -378,6 +378,10 @@ function bundle({ config, argsConfig }) {
     throw new Error("unreachable");
   }
 
+  if (!fs.existsSync(config.artefactsDir)) {
+    fs.mkdirSync(config.artefactsDir, { recursive: true });
+  }
+
   exec(cmd);
   log("Bundle created");
 }


### PR DESCRIPTION
1. Fix crash when `artefacts` dir is not present.
2. Fix files in `build.config.js` being silently ignored in Windows because they use POSIX path separator `/` while windows uses `\`.