### PR TITLE
Make UTxO overrides affect the balance

### DIFF
--- a/webext/CHANGELOG.md
+++ b/webext/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 1.3.0
+* Make UTxO override affect the balance
+  Previously, the utxo list override only affected the `getUtxos()` call and not the
+  `getBalance()` call.
+  The UI only allows overriding the ADA value of the balance.
+  With this change, the users will be able to use the same UI to override the token balance returned by `getBalance()`.
+
 # 1.2.0
 * Fix SundaeSwap hanging (#17)
 

--- a/webext/src/lib/CIP30/WalletApiInternal.ts
+++ b/webext/src/lib/CIP30/WalletApiInternal.ts
@@ -99,6 +99,12 @@ class WalletApiInternal {
 
     let address = this._getAddress();
     let utxos = await this.backend.getUtxos(address);
+
+    let overrides = await this.state.overridesGet(networkActive);
+    if (overrides != null) {
+      utxos = filterUtxos(utxos, overrides.hiddenUtxos);
+    }
+
     return Utils.sumUtxos(utxos);
   }
 
@@ -116,7 +122,8 @@ class WalletApiInternal {
       target = fiveAda;
     }
 
-    let utxos: CSL.TransactionUnspentOutput[] | null = await this.backend.getUtxos(address);
+    let utxos: CSL.TransactionUnspentOutput[] | null =
+      await this.backend.getUtxos(address);
 
     if (this.overridesEnabled) {
       let overrides = await this.state.overridesGet(networkActive);

--- a/webext/src/manifest.json
+++ b/webext/src/manifest.json
@@ -4,7 +4,7 @@
   "author": "chrome-web-store@mlabs.city",
   "description": "A wallet webextension for Cardano, with features that help development of dApps",
   "homepage_url": "https://github.com/mlabs-haskell/cardano-dev-wallet/",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "content_security_policy": {
     "extension_pages": "script-src 'self' 'wasm-unsafe-eval'; object-src 'self';"
   },

--- a/webext/src/popup/lib/pages/Overview.tsx
+++ b/webext/src/popup/lib/pages/Overview.tsx
@@ -69,7 +69,7 @@ function Balance({ api }: { api: WalletApiInternal }) {
       let balanceAda = lovelaceToAda(balance.coin());
       setBalance(balanceAda.toString());
     });
-  }, [api]);
+  }, [api, State.overrides.value]);
 
   let override = State.overrides.value?.balance;
 
@@ -454,7 +454,7 @@ function UtxoList({
             </>
           );
         })}
-    </section >
+    </section>
   );
 }
 


### PR DESCRIPTION
Previously, the utxo list overrides only affected the `getUtxos()` call and not the `getBalance()` call.
The UI only allows overriding the ADA value of the balance. With this change, the users will be able to use the same UI to override the token balance returned by `getBalance()`.