### PR TITLE
webext: backends: Fix Cors for local Ogmios

### DIFF
--- a/webext/src/lib/CIP30/Backends/OgmiosKupo.ts
+++ b/webext/src/lib/CIP30/Backends/OgmiosKupo.ts
@@ -54,7 +54,7 @@ class OgmiosKupoBackend implements Backend {
         method: "POST",
         headers: {
           Accept: "application/json",
-          "Content-Type": "application/json",
+          // "Content-Type": "application/json",
         },
         body: JSON.stringify({
           jsonrpc: "2.0",


### PR DESCRIPTION
**TL;DR:** This fix to allow extension able to work with Chrome, when Backend Providers is local Ogmios/Kupo 

**Explanation:**
When submit a tx to Ogmios, our extension will call to `/?SubmitTransaction` with header `"Content-Type": "application/json"` : [Ref](https://github.com/mlabs-haskell/cardano-dev-wallet/blob/master/webext/src/lib/CIP30/Backends/OgmiosKupo.ts#L57)

But Ogmios only response back with `Access-Control-Allow-Origin: *`, but without `Access-Control-Allow-Headers: content-type`. This lead to Chrome rejected the cross-origin request POST.

Simply remove that `Content-Type` header will do the trick.

